### PR TITLE
Expose SuiteSparseQR_C_backslash to Python as qr_solve.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ For some reason, no one ever wrapped that function of SuiteSparseQR for Python.
 # Usage
 
     # Perform QR decomposition of a sparse matrix
+    import numpy
+    import scipy
     import spqr
-    import scipy.sparse
     M = scipy.sparse.rand( 10, 10, density = 0.1 )
     Q, R, E, rank = spqr.qr( M )
     ## Should be approximately zero:
@@ -21,20 +22,20 @@ For some reason, no one ever wrapped that function of SuiteSparseQR for Python.
     #
     A = scipy.sparse.rand( 20, 10, density = 0.1 )  # 20 equations, 10 unknowns
     b = numpy.random.random(10)  # one RHS, but could also have many (in shape (10,k))
-    x = qr_solve( A, b, tolerance = 0 )
+    x = spqr.qr_solve( A, b, tolerance = 0 )
 
     # Solve many linear systems "M x = b for b in columns(B)"
     #
     B = scipy.sparse.rand( 10, 5, density = 0.1 )  # many RHS, sparse
-    x = qr_solve_sparse( M, B, tolerance = 0 )
+    x = spqr.qr_solve_sparse( M, B, tolerance = 0 )
 
     # Solve a system  M x = b  via QR decomposition
     #
     # This approach is slow due to explicit construction of Q, but may be
     # useful if a large number of systems need to be solved with the same M.
     #
-    import numpy
-    import scipy
+    # In this approach, R must not be exactly singular.
+    #
     Q, R, E, rank = spqr.qr( M )
     k = min(M.shape)
     R = R.tocsr()[:k,:]

--- a/README.md
+++ b/README.md
@@ -7,12 +7,43 @@ For some reason, no one ever wrapped that function of SuiteSparseQR for Python.
 
 # Usage
 
+    # Perform QR decomposition of a sparse matrix
     import spqr
     import scipy.sparse
     M = scipy.sparse.rand( 10, 10, density = 0.1 )
     Q, R, E, rank = spqr.qr( M )
     ## Should be approximately zero:
     print( abs( Q*R - M*spqr.permutation_from_E(E) ).sum() )
+
+    # Solve an overdetermined linear system  A x = b  in the least-squares sense
+    #
+    # (The same routine also works for the usual non-overdetermined case.)
+    #
+    A = scipy.sparse.rand( 20, 10, density = 0.1 )  # 20 equations, 10 unknowns
+    b = numpy.random.random(10)  # one RHS, but could also have many (in shape (10,k))
+    x = qr_solve( A, b, tolerance = 0 )
+
+    # Solve many linear systems "M x = b for b in columns(B)"
+    #
+    B = scipy.sparse.rand( 10, 5, density = 0.1 )  # many RHS, sparse
+    x = qr_solve_sparse( M, B, tolerance = 0 )
+
+    # Solve a system  M x = b  via QR decomposition
+    #
+    # This approach is slow due to explicit construction of Q, but may be
+    # useful if a large number of systems need to be solved with the same M.
+    #
+    import numpy
+    import scipy
+    Q, R, E, rank = spqr.qr( M )
+    k = min(M.shape)
+    R = R.tocsr()[:k,:]
+    Q = Q.tocsc()[:,:k]
+    Qb = (Q.T).dot(b)
+    result = scipy.sparse.linalg.spsolve(R, Qb)
+    x = numpy.empty_like(result)
+    x[E] = result[:]
+
 
 # Installation
 

--- a/cffi_asarray.py
+++ b/cffi_asarray.py
@@ -32,22 +32,22 @@ def asarray( ffi, ptr, length ):
     T = ffi.getctype( ffi.typeof( ptr ).item )
     # print( T )
     # print( ffi.sizeof( T ) )
-    
+
     if T not in ctype2dtype:
         raise RuntimeError( "Cannot create an array for element type: %s" % T )
-    
+
     return numpy.frombuffer( ffi.buffer( ptr, length*ffi.sizeof( T ) ), ctype2dtype[T] )
 
 def test():
     from cffi import FFI
     ffi = FFI()
-    
+
     N = 10
     ptr = ffi.new( "float[]", N )
-    
+
     arr = asarray( ffi, ptr, N )
     arr[:] = numpy.arange( N )
-    
+
     for i in range( N ):
         print( arr[i], ptr[i] )
 

--- a/spqr.py
+++ b/spqr.py
@@ -13,7 +13,7 @@ except ImportError:
     import spqr_gen
     spqr_gen.main()
     print( "=== ...compiled." )
-    
+
     from _spqr import ffi, lib
 
 import scipy.sparse
@@ -25,7 +25,7 @@ Helpful links:
     The primary docs:
     http://cffi.readthedocs.io/en/latest/overview.html
     http://cffi.readthedocs.io/en/latest/using.html
-    
+
     Some helpful examples for #define and NumPy:
     https://kogs-www.informatik.uni-hamburg.de/~seppke/content/teaching/wise1314/20131107_pridoehl-cffi.pdf
 '''
@@ -39,44 +39,44 @@ def deinit():
 
 def scipy2choldmod( scipy_A ):
     scipy_A = scipy_A.tocoo()
-    
+
     nnz = scipy_A.nnz
-    
+
     ## There is a potential performance win if we know A is symmetric and we
     ## can get only the upper or lower triangular elements.
     chol_A = lib.cholmod_l_allocate_triplet( scipy_A.shape[0], scipy_A.shape[1], nnz, 0, lib.CHOLMOD_REAL, cc )
-    
+
     Ai = ffi.cast( "SuiteSparse_long*", chol_A.i )
     Aj = ffi.cast( "SuiteSparse_long*", chol_A.j )
     Avals = ffi.cast( "double*", chol_A.x )
-    
+
     Ai[0:nnz] = scipy_A.row
     Aj[0:nnz] = scipy_A.col
     Avals[0:nnz] = scipy_A.data
-    
+
     chol_A.nnz = nnz
-    
+
     ## Print what cholmod sees as the matrix.
     # lib.cholmod_l_print_triplet( chol_A, "A".encode('utf-8'), cc )
     assert lib.cholmod_l_check_triplet( chol_A, cc ) == 1
-    
+
     ## Convert to a cholmod_sparse matrix.
     result = lib.cholmod_l_triplet_to_sparse( chol_A, nnz, cc )
     ## Free the space used by the cholmod triplet matrix.
     cholmod_free_triplet( chol_A )
-    
+
     return result
 
 def cholmod2scipy( chol_A ):
     ## Convert to a cholmod_triplet matrix.
     chol_A = lib.cholmod_l_sparse_to_triplet( chol_A, cc )
-    
+
     nnz = chol_A.nnz
-    
+
     Ai = ffi.cast( "SuiteSparse_long*", chol_A.i )
     Aj = ffi.cast( "SuiteSparse_long*", chol_A.j )
     Adata = ffi.cast( "double*", chol_A.x )
-    
+
     ## Have to pass through list().
     ## https://bitbucket.org/cffi/cffi/issues/292/cant-copy-data-to-a-numpy-array
     ## http://stackoverflow.com/questions/16276268/how-to-pass-a-numpy-array-into-a-cffi-function-and-how-to-get-one-back-out
@@ -84,7 +84,7 @@ def cholmod2scipy( chol_A ):
     i = numpy.zeros( nnz, dtype = numpy.int64 )
     j = numpy.zeros( nnz, dtype = numpy.int64 )
     data = numpy.zeros( nnz )
-    
+
     i[0:nnz] = list( Ai[0:nnz] )
     j[0:nnz] = list( Aj[0:nnz] )
     data[0:nnz] = list( Adata[0:nnz] )
@@ -95,15 +95,15 @@ def cholmod2scipy( chol_A ):
     i = cffi_asarray.asarray( ffi, Ai, nnz ).copy()
     j = cffi_asarray.asarray( ffi, Aj, nnz ).copy()
     data = cffi_asarray.asarray( ffi, Adata, nnz ).copy()
-    
+
     scipy_A = scipy.sparse.coo_matrix(
         ( data, ( i, j ) ),
         shape = ( chol_A.nrow, chol_A.ncol )
         )
-    
+
     ## Free the space used by the cholmod triplet matrix.
     cholmod_free_triplet( chol_A )
-    
+
     return scipy_A
 
 def cholmod_free_triplet( A ):
@@ -117,7 +117,7 @@ def qr( A, tolerance = None ):
     returns Q, R, E, rank such that:
         Q*R = A*permutation_from_E(E)
     rank is the estimated rank of A.
-    
+
     If optional `tolerance` parameter is negative, it has the following meanings:
         #define SPQR_DEFAULT_TOL ...       /* if tol <= -2, the default tol is used */
         #define SPQR_NO_TOL ...            /* if -2 < tol < 0, then no tol is used */
@@ -128,9 +128,9 @@ def qr( A, tolerance = None ):
     chol_Q = ffi.new("cholmod_sparse**")
     chol_R = ffi.new("cholmod_sparse**")
     chol_E = ffi.new("SuiteSparse_long**")
-    
+
     if tolerance is None: tolerance = lib.SPQR_DEFAULT_TOL
-    
+
     rank = lib.SuiteSparseQR_C_QR(
         ## Input
         lib.SPQR_ORDERING_DEFAULT,
@@ -143,10 +143,10 @@ def qr( A, tolerance = None ):
         chol_E,
         cc
         )
-    
+
     scipy_Q = cholmod2scipy( chol_Q[0] )
     scipy_R = cholmod2scipy( chol_R[0] )
-    
+
     ## If chol_E is null, there was no permutation.
     if chol_E == ffi.NULL:
         E = None
@@ -158,13 +158,13 @@ def qr( A, tolerance = None ):
         # E[0:A.shape[1]] = list( chol_E[0][0:A.shape[1]] )
         ## UPDATE: I can do this without going through list() or making two extra copies.
         E = cffi_asarray.asarray( ffi, chol_E[0], A.shape[1] ).copy()
-    
+
     ## Free cholmod stuff
     lib.cholmod_l_free_sparse( chol_Q, cc )
     lib.cholmod_l_free_sparse( chol_R, cc )
     ## Apparently we don't need to do this. (I get a malloc error.)
     # lib.cholmod_l_free( A.shape[1], ffi.sizeof("SuiteSparse_long"), chol_E, cc )
-    
+
     return scipy_Q, scipy_R, E, rank
 
 def permutation_from_E( E ):
@@ -174,7 +174,7 @@ def permutation_from_E( E ):
 
 if __name__ == '__main__':
     # Q, R, E, rank = qr( scipy.sparse.identity(10) )
-    
+
     M = scipy.sparse.rand( 10, 10, density = 0.1 )
     Q, R, E, rank = qr( M, tolerance = 0 )
     print( abs( Q*R - M*permutation_from_E(E) ).sum() )

--- a/spqr.py
+++ b/spqr.py
@@ -35,9 +35,14 @@ cc = ffi.new("cholmod_common*")
 lib.cholmod_l_start( cc )
 
 def deinit():
+    '''Deinitialize the CHOLMOD library.'''
     lib.cholmod_l_finish( cc )
 
 def scipy2cholmod( scipy_A ):
+    '''Convert a SciPy sparse matrix to a CHOLMOD sparse matrix.
+
+    The input is first internally converted to scipy.sparse.coo_matrix format.
+    '''
     scipy_A = scipy_A.tocoo()
 
     nnz = scipy_A.nnz
@@ -68,6 +73,7 @@ def scipy2cholmod( scipy_A ):
     return result
 
 def cholmod2scipy( chol_A ):
+    '''Convert a CHOLMOD sparse matrix to a scipy.sparse.coo_matrix.'''
     ## Convert to a cholmod_triplet matrix.
     chol_A = lib.cholmod_l_sparse_to_triplet( chol_A, cc )
 
@@ -107,6 +113,7 @@ def cholmod2scipy( chol_A ):
     return scipy_A
 
 def cholmod_free_triplet( A ):
+    '''Deallocate a CHOLMOD triplet format matrix.'''
     A_ptr = ffi.new("cholmod_triplet**")
     A_ptr[0] = A
     lib.cholmod_l_free_triplet( A_ptr, cc )
@@ -121,6 +128,8 @@ def qr( A, tolerance = None ):
     If optional `tolerance` parameter is negative, it has the following meanings:
         #define SPQR_DEFAULT_TOL ...       /* if tol <= -2, the default tol is used */
         #define SPQR_NO_TOL ...            /* if -2 < tol < 0, then no tol is used */
+
+    The performance-optimal format for A is scipy.sparse.coo_matrix.
     '''
 
     chol_A = scipy2cholmod( A )
@@ -168,6 +177,7 @@ def qr( A, tolerance = None ):
     return scipy_Q, scipy_R, E, rank
 
 def permutation_from_E( E ):
+    '''Convert permutation vector E (length n) to permutation matrix (n by n).'''
     n = len( E )
     j = numpy.arange( n )
     return scipy.sparse.coo_matrix( ( numpy.ones(n), ( E, j ) ), shape = ( n, n ) )

--- a/spqr.py
+++ b/spqr.py
@@ -37,7 +37,7 @@ lib.cholmod_l_start( cc )
 def deinit():
     lib.cholmod_l_finish( cc )
 
-def scipy2choldmod( scipy_A ):
+def scipy2cholmod( scipy_A ):
     scipy_A = scipy_A.tocoo()
 
     nnz = scipy_A.nnz
@@ -122,9 +122,9 @@ def qr( A, tolerance = None ):
         #define SPQR_DEFAULT_TOL ...       /* if tol <= -2, the default tol is used */
         #define SPQR_NO_TOL ...            /* if -2 < tol < 0, then no tol is used */
     '''
-    
-    chol_A = scipy2choldmod( A )
-    
+
+    chol_A = scipy2cholmod( A )
+
     chol_Q = ffi.new("cholmod_sparse**")
     chol_R = ffi.new("cholmod_sparse**")
     chol_E = ffi.new("SuiteSparse_long**")

--- a/spqr.py
+++ b/spqr.py
@@ -34,9 +34,12 @@ Helpful links:
 cc = ffi.new("cholmod_common*")
 lib.cholmod_l_start( cc )
 
-def deinit():
+## Set up cholmod deinit to run when Python exits
+def _deinit():
     '''Deinitialize the CHOLMOD library.'''
     lib.cholmod_l_finish( cc )
+import atexit
+atexit.register(_deinit)
 
 def scipy2cholmod( scipy_A ):
     '''Convert a SciPy sparse matrix to a CHOLMOD sparse matrix.

--- a/spqr_gen.py
+++ b/spqr_gen.py
@@ -114,6 +114,54 @@ int cholmod_l_free_sparse
     cholmod_common *Common
 ) ;
 
+/* ========================================================================== */
+/* === Core/cholmod_dense =================================================== */
+/* ========================================================================== */
+
+/* A dense matrix in column-oriented form.  It has no itype since it contains
+ * no integers.  Entry in row i and column j is located in x [i+j*d].
+ */
+
+typedef struct cholmod_dense_struct
+{
+    size_t nrow ;	/* the matrix is nrow-by-ncol */
+    size_t ncol ;
+    size_t nzmax ;	/* maximum number of entries in the matrix */
+    size_t d ;		/* leading dimension (d >= nrow must hold) */
+    void *x ;		/* size nzmax or 2*nzmax, if present */
+    void *z ;		/* size nzmax, if present */
+    int xtype ;		/* pattern, real, complex, or zomplex */
+    int dtype ;		/* x and z double or float */
+
+} cholmod_dense ;
+
+/* -------------------------------------------------------------------------- */
+/* cholmod_allocate_dense:  allocate a dense matrix (contents uninitialized) */
+/* -------------------------------------------------------------------------- */
+
+cholmod_dense *cholmod_l_allocate_dense
+(
+    /* ---- input ---- */
+    size_t nrow,	/* # of rows of matrix */
+    size_t ncol,	/* # of columns of matrix */
+    size_t d,		/* leading dimension */
+    int xtype,		/* CHOLMOD_REAL, _COMPLEX, or _ZOMPLEX */
+    /* --------------- */
+    cholmod_common *Common
+) ;
+
+/* -------------------------------------------------------------------------- */
+/* cholmod_free_dense:  free a dense matrix */
+/* -------------------------------------------------------------------------- */
+
+int cholmod_l_free_dense
+(
+    /* ---- in/out --- */
+    cholmod_dense **X,	/* dense matrix to deallocate, NULL on output */
+    /* --------------- */
+    cholmod_common *Common
+) ;
+
 /*
  * ============================================================================
  * === cholmod_triplet ========================================================
@@ -229,6 +277,16 @@ SuiteSparse_long SuiteSparseQR_C_QR /* returns rank(A) est., (-1) if failure */
     cholmod_sparse **Q,         /* m-by-e sparse matrix */
     cholmod_sparse **R,         /* e-by-n sparse matrix */
     SuiteSparse_long **E,       /* size n column perm, NULL if identity */
+    cholmod_common *cc          /* workspace and parameters */
+) ;
+
+/* X = A\B where B is dense */
+cholmod_dense *SuiteSparseQR_C_backslash    /* returns X, NULL if failure */
+(
+    int ordering,               /* all, except 3:given treated as 0:fixed */
+    double tol,                 /* columns with 2-norm <= tol treated as 0 */
+    cholmod_sparse *A,          /* m-by-n sparse matrix */
+    cholmod_dense  *B,          /* m-by-k */
     cholmod_common *cc          /* workspace and parameters */
 ) ;
 

--- a/spqr_gen.py
+++ b/spqr_gen.py
@@ -290,6 +290,17 @@ cholmod_dense *SuiteSparseQR_C_backslash    /* returns X, NULL if failure */
     cholmod_common *cc          /* workspace and parameters */
 ) ;
 
+ /* X = A\B where B is sparse */
+cholmod_sparse *SuiteSparseQR_C_backslash_sparse   /* returns X, or NULL */
+(
+    /* inputs: */
+    int ordering,               /* all, except 3:given treated as 0:fixed */
+    double tol,                 /* columns with 2-norm <= tol treated as 0 */
+    cholmod_sparse *A,          /* m-by-n sparse matrix */
+    cholmod_sparse *B,          /* m-by-k */
+    cholmod_common *cc          /* workspace and parameters */
+) ;
+
 #define SPQR_ORDERING_FIXED ...
 #define SPQR_ORDERING_NATURAL ...
 #define SPQR_ORDERING_COLAMD ...


### PR DESCRIPTION
Hi,

Thanks for the wrapper, almost exactly what I was looking for. :)

As for the "almost" part, here is a quick addition to PySPQR that allows solving A x = b in the least-squares sense. Using SuiteSparseQR_C_backslash for this is usually much faster than first explicitly constructing Q via SuiteSparseQR_C_QR (although this approach is now also documented in the docstrings).

I also took the liberty to remove trailing whitespace, and added/expanded some docstrings.

I've tested this with both the small test in main() and an approximately 4500x1500 matrix in a project I'm working on, and it works. Solve time for the 4500x1500 is under 3 seconds on an i7 (whereas first decomposing with qr() takes about a minute).

I'm not 100% sure if I did all the low-level stuff (memory handling / data type conversion) correctly - comments are welcome.