### PR TITLE
Add rz decomposition routine

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,13 @@
 from __future__ import division, print_function, absolute_import
 
 from setuptools import setup
+import numpy
+import os
+
+try:
+    include_dirs=[numpy.get_include(), os.path.join(os.environ['CONDA_PREFIX'], 'include')]
+except Exception:
+    include_dirs=None
 
 setup(
     name = "sparseqr",
@@ -54,7 +61,7 @@ Supports Python 2.7 and 3.4.
     cffi_modules = ["sparseqr/sparseqr_gen.py:ffibuilder"],
     install_requires = ["numpy", "scipy", "cffi>=1.0.0"],
     provides = ["sparseqr"],
-
+    include_dirs=include_dirs,
     # keywords for PyPI (in case you upload your project)
     #
     # e.g. the keywords your project uses as topics on GitHub, minus "python" (if there)

--- a/sparseqr/__init__.py
+++ b/sparseqr/__init__.py
@@ -20,5 +20,5 @@ from __future__ import absolute_import
 __version__ = '1.0.0'
 
 # import the important things into the package's top-level namespace.
-from .sparseqr import qr, qz, solve, permutation_vector_to_matrix
+from .sparseqr import qr, rz, solve, permutation_vector_to_matrix
 

--- a/sparseqr/__init__.py
+++ b/sparseqr/__init__.py
@@ -20,5 +20,5 @@ from __future__ import absolute_import
 __version__ = '1.0.0'
 
 # import the important things into the package's top-level namespace.
-from .sparseqr import qr, solve, permutation_vector_to_matrix
+from .sparseqr import qr, qz, solve, permutation_vector_to_matrix
 

--- a/sparseqr/sparseqr.py
+++ b/sparseqr/sparseqr.py
@@ -199,8 +199,7 @@ def cholmod_free_dense( A ):
 
 
 ## Solvers
-#BS: I took the function definition for SuiteSpareQR_C and replaced everything that looked unnecessary with ffi.NULL.  
-def qz(A, B, tolerance = None):
+def rz(A, B, tolerance = None):
     getCTX=int(0)
     chol_A = scipy2cholmodsparse( A )
     chol_b = numpy2cholmoddense(  B )

--- a/sparseqr/sparseqr_gen.py
+++ b/sparseqr/sparseqr_gen.py
@@ -267,6 +267,36 @@ void *cholmod_l_free	/* always returns NULL */
     cholmod_common *Common
 ) ;
 
+/* cs_spsolve 
+int cs_spsolve 
+{
+*/
+
+
+
+/* [Z,R,E] = qz(A), returning Z, R, and E */
+SuiteSparse_long SuiteSparseQR_C /* returns ???, (-1) if failure */
+(
+    /* inputs: */
+    int ordering,               /* all, except 3:given treated as 0:fixed */
+    double tol,                 /* columns with 2-norm <= tol treated as 0 */
+    SuiteSparse_long econ,      /* e = max(min(m,econ),rank(A)) */
+    int getCTX,                 /* 0:Z=C, 1:Z=c', 2: z=X */
+    cholmod_sparse *A,          /* m-by-n sparse matrix to factorize */
+    cholmod_sparse *Bsparse,
+    cholmod_dense *Bdense,
+    /* outputs: */
+    cholmod_sparse **Zsparse,   /* m-by-e sparse matrix */
+    cholmod_dense **Zdense,
+    cholmod_sparse **R,         /* e-by-n sparse matrix */
+    SuiteSparse_long **E,       /* size n column perm, NULL if identity */
+    cholmod_sparse **H,         /* m-by-nh Householder vectors */
+    SuiteSparse_long **HPinv,   /* size m row permutation */
+    cholmod_dense **HTau,       /* 1-by-nh Householder coefficients */
+    cholmod_common *cc          /* workspace and parameters */
+) ;
+
+
 /* [Q,R,E] = qr(A), returning Q as a sparse matrix */
 SuiteSparse_long SuiteSparseQR_C_QR /* returns rank(A) est., (-1) if failure */
 (
@@ -281,6 +311,7 @@ SuiteSparse_long SuiteSparseQR_C_QR /* returns rank(A) est., (-1) if failure */
     SuiteSparse_long **E,       /* size n column perm, NULL if identity */
     cholmod_common *cc          /* workspace and parameters */
 ) ;
+
 
 /* X = A\B where B is dense */
 cholmod_dense *SuiteSparseQR_C_backslash    /* returns X, NULL if failure */

--- a/sparseqr/sparseqr_gen.py
+++ b/sparseqr/sparseqr_gen.py
@@ -274,7 +274,7 @@ int cs_spsolve
 
 
 
-/* [Z,R,E] = qz(A), returning Z, R, and E */
+/* [Z,R,E] = rz(A), returning Z, R, and E */
 SuiteSparse_long SuiteSparseQR_C /* returns ???, (-1) if failure */
 (
     /* inputs: */


### PR DESCRIPTION
When solving large linear systems, it's nice to be able to use parts of a QR decomposition without forming the Q matrix.  Suitesparse allows a Q-less decomposition, which forms R and Z such that z=Q^Td.  The modifications I made to the code let PySPQR return Q and Z for sparse systems.

