### PR TITLE
Add support for "economy" decomposition.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ r = rank  # r could be min(M.shape) if M is full-rank
 # The system is only solvable if the lower part of Q.T @ B is all zero:
 print( "System is solvable if this is zero:", abs( (( Q.tocsc()[:,r:] ).T ).dot( B ) ).sum() )
 
+# Systems with large non-square matrices can benefit from "economy" decomposition.
+M = scipy.sparse.rand( 20, 5, density=0.1 )
+Q, R, E, rank = sparseqr.qr( M )
+print("Q shape:", Q.shape)  # Q shape: (20, 20)
+print("R shape:", R.shape)  # R shape: (20, 5)
+Q, R, E, rank = sparseqr.qr( M, economy=True )
+print("Q shape:", Q.shape)  # Q shape: (20, 5)
+print("R shape:", R.shape)  # R shape: (5, 5)
+
 # Use CSC format for fast indexing of columns.
 R = R.tocsc()[:r,:r]
 Q = Q.tocsc()[:,:r]

--- a/sparseqr/sparseqr.py
+++ b/sparseqr/sparseqr.py
@@ -200,7 +200,7 @@ def cholmod_free_dense( A ):
 
 ## Solvers
 
-def qr( A, tolerance = None ):
+def qr( A, tolerance = None, economy = False ):
     '''
     Given a sparse matrix A,
     returns Q, R, E, rank such that:
@@ -254,11 +254,13 @@ def qr( A, tolerance = None ):
 
     if tolerance is None: tolerance = lib.SPQR_DEFAULT_TOL
 
+    econ = A.shape[1] if economy else A.shape[0]
+
     rank = lib.SuiteSparseQR_C_QR(
         ## Input
         lib.SPQR_ORDERING_DEFAULT,
         tolerance,
-        A.shape[0],
+        econ,
         chol_A,
         ## Output
         chol_Q,

--- a/sparseqr/sparseqr.py
+++ b/sparseqr/sparseqr.py
@@ -200,7 +200,7 @@ def cholmod_free_dense( A ):
 
 ## Solvers
 
-def qr( A, tolerance = None, economy = False ):
+def qr( A, tolerance = None, economy = None ):
     '''
     Given a sparse matrix A,
     returns Q, R, E, rank such that:
@@ -210,6 +210,11 @@ def qr( A, tolerance = None, economy = False ):
     If optional `tolerance` parameter is negative, it has the following meanings:
         #define SPQR_DEFAULT_TOL ...       /* if tol <= -2, the default tol is used */
         #define SPQR_NO_TOL ...            /* if -2 < tol < 0, then no tol is used */
+
+    For A an m-by-n matrix, Q will be m-by-m and R will be m-by-n.
+
+    If optional `economy` parameter is truthy, Q will be m-by-k and R will be
+    k-by-n, where k = min(m, n).
 
     The performance-optimal format for A is scipy.sparse.coo_matrix.
 
@@ -253,6 +258,8 @@ def qr( A, tolerance = None, economy = False ):
     chol_E = ffi.new("SuiteSparse_long**")
 
     if tolerance is None: tolerance = lib.SPQR_DEFAULT_TOL
+
+    if economy is None: economy = False
 
     econ = A.shape[1] if economy else A.shape[0]
 


### PR DESCRIPTION
For m-by-n matrices with n < m, the "economy" decomposition computes only the first n columns of Q and n rows of R.  When n >= m, the economy decomposition is equivalent to the usual decomposition.

This is the functionality provided by passing in the string 'econ' or the number 0 to the MATLAB qr function described here: https://www.mathworks.com/help/symbolic/qr.html