### PR TITLE
Add numeric economy option to be passed to SPQR

### DIFF
--- a/sparseqr/sparseqr.py
+++ b/sparseqr/sparseqr.py
@@ -305,7 +305,11 @@ def qr( A, tolerance = None, economy = None ):
 
     if economy is None: economy = False
 
-    econ = A.shape[1] if economy else A.shape[0]
+    if isinstance(economy, bool):
+        econ = A.shape[1] if economy else A.shape[0]
+    else:
+        # Treat as a number
+        econ = int(economy)
 
     rank = lib.SuiteSparseQR_C_QR(
         ## Input


### PR DESCRIPTION
The "economy" option can be used in SPQR to compute a QR factorization of a (m x n) matrix with m < n consisting of blocks Q_1, and Q_2, where Q_1 has as shape of (m x n) and Q_2 of (m x k - n). For k = n we get the reduced form, for k = m the full one. For k in between m and n, SPQR yields a block that spans part of the kernel of A. This patch adds this functionality to PySPQR.