### PR TITLE
Qmult

### DIFF
--- a/sparseqr/__init__.py
+++ b/sparseqr/__init__.py
@@ -20,5 +20,5 @@ from __future__ import absolute_import
 __version__ = '1.2.1'
 
 # import the important things into the package's top-level namespace.
-from .sparseqr import qr, rz, solve, permutation_vector_to_matrix
+from .sparseqr import qr, rz, solve, permutation_vector_to_matrix, qr_factorize,qmult
 

--- a/sparseqr/sparseqr.py
+++ b/sparseqr/sparseqr.py
@@ -391,6 +391,7 @@ def qmult( QR, X, method=1):
         a dense matrix
     returns Q applied to X in a dense matrix    
 
+    From the suitesparse documentation:
     /*
     Applies Q in Householder form (as stored in the QR factorization object
     returned by SuiteSparseQR_C_factorize) to a dense matrix X.

--- a/sparseqr/sparseqr.py
+++ b/sparseqr/sparseqr.py
@@ -351,6 +351,76 @@ def qr( A, tolerance = None, economy = None ):
     return scipy_Q, scipy_R, E, rank
 
 
+def qr_factorize( A, tolerance = None):
+    '''
+    Given a sparse matrix A,
+    returns a QR factorization in householder form    
+
+    If optional `tolerance` parameter is negative, it has the following meanings:
+        #define SPQR_DEFAULT_TOL ...       /* if tol <= -2, the default tol is used */
+        #define SPQR_NO_TOL ...            /* if -2 < tol < 0, then no tol is used */
+
+    For A an m-by-n matrix, Q will be m-by-m and R will be m-by-n.
+
+        The performance-optimal format for A is scipy.sparse.coo_matrix.
+
+    '''
+
+    chol_A = scipy2cholmodsparse( A )
+
+    if tolerance is None: tolerance = lib.SPQR_DEFAULT_TOL
+
+    QR = lib.SuiteSparseQR_C_factorize(
+        ## Input
+        lib.SPQR_ORDERING_DEFAULT,
+        tolerance,
+        chol_A,
+        cc
+        )
+
+    cholmod_free_sparse( chol_A )
+    ## Apparently we don't need to do this. (I get a malloc error.)
+    # lib.cholmod_l_free( A.shape[1], ffi.sizeof("SuiteSparse_long"), chol_E, cc )
+
+    return QR
+
+
+def qmult( QR, X, method=1):
+    '''
+    Given a QR factorization struct
+        a dense matrix
+    returns Q applied to X in a dense matrix    
+
+    /*
+    Applies Q in Householder form (as stored in the QR factorization object
+    returned by SuiteSparseQR_C_factorize) to a dense matrix X.
+
+    method SPQR_QTX (0): Y = Q'*X
+    method SPQR_QX  (1): Y = Q*X
+    method SPQR_XQT (2): Y = X*Q'
+    method SPQR_XQ  (3): Y = X*Q
+    */
+
+    '''
+
+    chol_X = numpy2cholmoddense(  X )
+
+    chol_Y = lib.SuiteSparseQR_C_qmult(
+        ## Input
+        method, 
+        QR,
+        chol_X,
+        cc
+        )
+    numpy_Y = cholmoddense2numpy( chol_Y )
+
+    ## Free cholmod stuff
+    cholmod_free_dense(  chol_X )
+    cholmod_free_dense(  chol_Y )
+
+    return numpy_Y
+
+
 def solve( A, b, tolerance = None ):
     '''
     Given a sparse m-by-n matrix A, and dense or sparse m-by-k matrix (storing k RHS vectors) b,

--- a/sparseqr/sparseqr_gen.py
+++ b/sparseqr/sparseqr_gen.py
@@ -362,6 +362,105 @@ cholmod_sparse *SuiteSparseQR_C_backslash_sparse   /* returns X, or NULL */
     cholmod_common *cc          /* workspace and parameters */
 ) ;
 
+/* ========================================================================== */
+/* === SuiteSparseQR_C_factorization ======================================== */
+/* ========================================================================== */
+
+/* A real or complex QR factorization, computed by SuiteSparseQR_C_factorize */
+typedef struct SuiteSparseQR_C_factorization_struct
+{
+    int xtype ;                 /* CHOLMOD_REAL or CHOLMOD_COMPLEX */
+    void *factors ;             /* from SuiteSparseQR_factorize <double> or
+                                        SuiteSparseQR_factorize <Complex> */
+
+} SuiteSparseQR_C_factorization ;
+
+/* ========================================================================== */
+/* === SuiteSparseQR_C_factorize ============================================ */
+/* ========================================================================== */
+
+SuiteSparseQR_C_factorization *SuiteSparseQR_C_factorize
+(
+    /* inputs: */
+    int ordering,               /* all, except 3:given treated as 0:fixed */
+    double tol,                 /* columns with 2-norm <= tol treated as 0 */
+    cholmod_sparse *A,          /* m-by-n sparse matrix */
+    cholmod_common *cc          /* workspace and parameters */
+) ;
+
+/* ========================================================================== */
+/* === SuiteSparseQR_C_symbolic ============================================= */
+/* ========================================================================== */
+
+SuiteSparseQR_C_factorization *SuiteSparseQR_C_symbolic
+(
+    /* inputs: */
+    int ordering,               /* all, except 3:given treated as 0:fixed */
+    int allow_tol,              /* if TRUE allow tol for rank detection */
+    cholmod_sparse *A,          /* m-by-n sparse matrix, A->x ignored */
+    cholmod_common *cc          /* workspace and parameters */
+) ;
+
+/* ========================================================================== */
+/* === SuiteSparseQR_C_numeric ============================================== */
+/* ========================================================================== */
+
+int SuiteSparseQR_C_numeric
+(
+    /* inputs: */
+    double tol,                 /* treat columns with 2-norm <= tol as zero */
+    cholmod_sparse *A,          /* sparse matrix to factorize */
+    /* input/output: */
+    SuiteSparseQR_C_factorization *QR,
+    cholmod_common *cc          /* workspace and parameters */
+) ;
+
+/* ========================================================================== */
+/* === SuiteSparseQR_C_free ================================================= */
+/* ========================================================================== */
+
+/* Free the QR factors computed by SuiteSparseQR_C_factorize */
+int SuiteSparseQR_C_free        /* returns TRUE (1) if OK, FALSE (0) otherwise*/
+(
+    SuiteSparseQR_C_factorization **QR,
+    cholmod_common *cc          /* workspace and parameters */
+) ;
+
+/* ========================================================================== */
+/* === SuiteSparseQR_C_solve ================================================ */
+/* ========================================================================== */
+
+cholmod_dense* SuiteSparseQR_C_solve    /* returnx X, or NULL if failure */
+(
+    int system,                 /* which system to solve */
+    SuiteSparseQR_C_factorization *QR,  /* of an m-by-n sparse matrix A */
+    cholmod_dense *B,           /* right-hand-side, m-by-k or n-by-k */
+    cholmod_common *cc          /* workspace and parameters */
+) ;
+
+/* ========================================================================== */
+/* === SuiteSparseQR_C_qmult ================================================ */
+/* ========================================================================== */
+
+/*
+    Applies Q in Householder form (as stored in the QR factorization object
+    returned by SuiteSparseQR_C_factorize) to a dense matrix X.
+
+    method SPQR_QTX (0): Y = Q'*X
+    method SPQR_QX  (1): Y = Q*X
+    method SPQR_XQT (2): Y = X*Q'
+    method SPQR_XQ  (3): Y = X*Q
+*/
+
+cholmod_dense *SuiteSparseQR_C_qmult /* returns Y, or NULL on failure */
+(
+    /* inputs: */
+    int method,                 /* 0,1,2,3 */
+    SuiteSparseQR_C_factorization *QR,  /* of an m-by-n sparse matrix A */
+    cholmod_dense *X,           /* size m-by-n with leading dimension ldx */
+    cholmod_common *cc          /* workspace and parameters */
+) ;   
+                        
 #define SPQR_ORDERING_FIXED ...
 #define SPQR_ORDERING_NATURAL ...
 #define SPQR_ORDERING_COLAMD ...

--- a/test/test.py
+++ b/test/test.py
@@ -71,7 +71,9 @@ M = scipy.sparse.rand( 100, 100, density=0.05 )
 #perform QR factorization, but store in Householder form
 QR= sparseqr.qr_factorize( M )
 X = numpy.zeros((M.shape[0],1))
-X[-1,0]=1 #change last entry to a 1 (this allows us to )
+#change last entry of the first column to a 1 
+# this allows us to construct only the first column of Q
+X[-1,0]=1 
 
 Y = sparseqr.qmult(QR,X)
 print("Y shape (should be 100x1):",Y.shape)

--- a/test/test.py
+++ b/test/test.py
@@ -64,3 +64,14 @@ x[E] = x.copy()
 # Recover a solution (as a sparse matrix):
 x = scipy.sparse.vstack( ( result.tocoo(), scipy.sparse.coo_matrix( ( M.shape[1] - rank, B.shape[1] ), dtype = result.dtype ) ) )
 x.row = E[ x.row ]
+
+#initialize QR Factorization object
+M = scipy.sparse.rand( 100, 100, density=0.05 )
+
+#perform QR factorization, but store in Householder form
+QR= sparseqr.qr_factorize( M )
+X = numpy.zeros((M.shape[0],1))
+X[-1,0]=1 #change last entry to a 1 (this allows us to )
+
+Y = sparseqr.qmult(QR,X)
+print("Y shape (should be 100x1):",Y.shape)


### PR DESCRIPTION
add the ability to construct a qr factorization object via calling qr_factorize. This stores the qr factorization in householder form. Next, the product of a multiplication with Q can be constructed by using qmult. This prevents the explicit construction of Q, but allows one do also extract columns from Q by multiplication with unit vectors. Unlike the explicit factorization, if only a few columns of Q are needed, qr_factorize and qmult scale approximately quadratically instead of cubicly.