### PR TITLE
sparseqr/sparseqr_gen.py : add typical location for SuiteSparseQR_C.h

### DIFF
--- a/sparseqr/sparseqr_gen.py
+++ b/sparseqr/sparseqr_gen.py
@@ -29,6 +29,9 @@ if 'CONDA_DEFAULT_ENV' in os.environ:
     homedir = expanduser("~")
     include_dirs.append( join(homedir, 'anaconda3', 'envs', os.environ['CONDA_DEFAULT_ENV'], 'Library', 'include', 'suitesparse') )
     include_dirs.append( join(homedir, 'miniconda3', 'envs', os.environ['CONDA_DEFAULT_ENV'], 'Library', 'include', 'suitesparse') )
+# for compatibility with hosted jupyter environments
+if 'CONDA_PREFIX' in os.environ:
+    include_dirs.append( join(os.environ['CONDA_PREFIX'], 'include', 'suitesparse'))
 
 if platform.system() == 'Windows':
     # https://github.com/yig/PySPQR/issues/6


### PR DESCRIPTION

On environments that use conda, the suitesparse include directory will often be under the user's conda prefix.  We can find it with:
include_dirs.append( join(os.environ['CONDA_PREFIX'], 'include', 'suitesparse'))

I added some logic to make sure there's a 'CONDA_PREFIX' in the environment.