### PR TITLE
Allow numpy >2, look for libraries a bit harder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ exclude = ["sparseqr/_sparseqr*"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-numpy = "^1.21"
+numpy = ">1.2"
 scipy = "^1.0"
 cffi = "^1.0"
 

--- a/sparseqr/sparseqr_gen.py
+++ b/sparseqr/sparseqr_gen.py
@@ -27,11 +27,12 @@ else:
 # for compatibility with conda envs
 if 'CONDA_DEFAULT_ENV' in os.environ:
     homedir = expanduser("~")
-    include_dirs.append( join(homedir, 'anaconda3', 'envs', os.environ['CONDA_DEFAULT_ENV'], 'Library', 'include', 'suitesparse') )
-    include_dirs.append( join(homedir, 'miniconda3', 'envs', os.environ['CONDA_DEFAULT_ENV'], 'Library', 'include', 'suitesparse') )
-# for compatibility with hosted jupyter environments
-if 'CONDA_PREFIX' in os.environ:
-    include_dirs.append( join(os.environ['CONDA_PREFIX'], 'include', 'suitesparse'))
+
+    for packager in ['anaconda3','miniconda3','condaforge','miniforge','mambaforge']:
+        for sub in ['','Library']:
+            thedir=join(homedir, packager, 'envs', os.environ['CONDA_DEFAULT_ENV'], sub, 'include', 'suitesparse')
+            if os.path.isdir(thedir):
+                include_dirs.append(thedir)
 
 if platform.system() == 'Windows':
     # https://github.com/yig/PySPQR/issues/6


### PR DESCRIPTION
Hi Yotam,

Now that I'm using mambaforge in place of miniconda/condaforge, the suitesparse libraries are a little harder to find.  I added some additional code to look for them during the build process.

I've also upgraded to numpy 2.2, and it looks like this isn't yet causing problems for PySPQR, so I updated the constraint in pyproject.toml.

Happy new year!
--Ben